### PR TITLE
Refactor Postgres to be more flexible

### DIFF
--- a/src/Postgres.ts
+++ b/src/Postgres.ts
@@ -16,15 +16,16 @@ interface IPoolFileConfig {
   port: number;
 }
 
-interface IAttributes {
-  [key: string]: any;
-}
-
 export interface IDatabase {
   query(sql: string): Promise<QueryResult>;
-  insert(tableName: string, attributes: IAttributes): Promise<any[]>;
-  select(tableName: string, attributes: IAttributes): Promise<any[]>;
+  insert<T extends Record<string, any>>(tableName: string, attributes: T): Promise<(T & IWithId)[]>;
+  select(tableName: string, attributes: Record<string, any>): Promise<any[]>;
   end(): Promise<void>;
+}
+
+export interface IWithId {
+  id: number;
+  [key: string]: any;
 }
 
 export interface IPool extends Pool {
@@ -82,7 +83,7 @@ export default class Postgres implements IPostgres {
     return new Pool(config);
   }
 
-  async insert(tableName: string, attributes: any): Promise<any[]> {
+  async insert(tableName: string, attributes: Record<string, any>): Promise<any[]> {
     const fields = Object.keys(attributes);
     const fieldsStr: string = fields.join(', ');
 
@@ -105,7 +106,7 @@ export default class Postgres implements IPostgres {
     return created.rows;
   }
 
-  async select(tableName: string, attributes: IAttributes): Promise<any[]> {
+  async select(tableName: string, attributes: Record<string, any>): Promise<(Record<string, any> & IWithId)[]> {
     const whereArr = Object.keys(attributes).map((field) => {
       let value: any = attributes[field];
       if (typeof value === 'string') {

--- a/src/PostgresQuery.ts
+++ b/src/PostgresQuery.ts
@@ -1,0 +1,58 @@
+import { QueryResult } from 'pg';
+import PG_Interface from './PG_Interface';
+
+export interface IWithId {
+  id: number;
+  [key: string]: any;
+}
+
+export interface IDatabase {
+  insert<T extends Record<string, any>>(tableName: string, attributes: T): Promise<(T & IWithId)[]>;
+  select(tableName: string, attributes: Record<string, any>): Promise<any[]>;
+}
+
+export default class PostgresQuery implements IDatabase {
+  pgInterface: PG_Interface;
+
+  constructor(pgInterface: PG_Interface) {
+    this.pgInterface = pgInterface;
+  }
+
+  async insert<T extends Record<string, any>>(tableName: string, attributes: T): Promise<(T & IWithId)[]> {
+    const fields = Object.keys(attributes);
+    const fieldsStr: string = fields.join(', ');
+
+    const values = fields.map((field) => {
+      let attribute = attributes[field];
+
+      if (typeof attribute === 'string') {
+        attribute = `'${attribute}'`;
+      }
+
+      return attribute;
+    });
+
+    const valuesStr: string = values.join(', ');
+
+    const created: QueryResult = await this.pgInterface.query(
+      `INSERT INTO ${tableName} (${fieldsStr}) VALUES (${valuesStr}) RETURNING *;`,
+    );
+
+    return created.rows;
+  }
+
+  async select(tableName: string, attributes: Record<string, any>): Promise<any[]> {
+    const whereArr = Object.keys(attributes).map((field) => {
+      let value: any = attributes[field];
+      if (typeof value === 'string') {
+        value = `'${value}'`;
+      }
+      return `${field}=${value}`;
+    });
+
+    const whereStr = whereArr.length ? `WHERE ${whereArr.join(' AND ')}` : '';
+
+    const results: QueryResult = await this.pgInterface.query(`SELECT * FROM ${tableName} ${whereStr};`);
+    return results.rows;
+  }
+}

--- a/src/pages/AddTransactionPage.ts
+++ b/src/pages/AddTransactionPage.ts
@@ -23,7 +23,7 @@ export default class AddTransactionPage implements IPage {
     const otherUser: IUser | undefined = await this.getUser();
 
     if (!otherUser) {
-      throw Error('The other user cannot be undefined.')
+      throw Error('The other user cannot be undefined.');
     }
 
     const name: string = await this.getName();
@@ -56,7 +56,7 @@ export default class AddTransactionPage implements IPage {
     }, []);
 
     const answer: Answers = await this.prompter.promptList('Who was this transaction with?', choices);
-    return users.find(user => user.first_name === answer.action);
+    return users.find((user) => user.first_name === answer.action);
   }
 
   private async getName(): Promise<string> {
@@ -100,7 +100,7 @@ export default class AddTransactionPage implements IPage {
       const answer: Answers = await this.prompter.promptNumber('How much did it cost?');
       cost = answer.number;
 
-      if (!isNaN(cost) && cost > 0 && !(cost * 100 % 1)) {
+      if (!isNaN(cost) && cost > 0 && !((cost * 100) % 1)) {
         break;
       }
 

--- a/src/tables/TransactionTable.ts
+++ b/src/tables/TransactionTable.ts
@@ -1,4 +1,4 @@
-import { IDatabase } from '../Postgres';
+import { IDatabase } from '../PostgresQuery';
 
 export interface ITransaction {
   id: number;
@@ -15,14 +15,13 @@ export interface ITransactionUser {
 }
 
 export interface ITransactionTable {
-  database: IDatabase;
   create(lenderId: number, borrowerId: number, name: string, date: Date, cost: number): Promise<ITransaction>;
 }
 
 export default class TransactionTable implements ITransactionTable {
-  database: IDatabase;
-  constructor(database: IDatabase) {
-    this.database = database;
+  private databaseQuery: IDatabase;
+  constructor(databaseQuery: IDatabase) {
+    this.databaseQuery = databaseQuery;
   }
 
   async create(lenderId: number, borrowerId: number, name: string, date: Date, cost: number): Promise<ITransaction> {
@@ -34,13 +33,13 @@ export default class TransactionTable implements ITransactionTable {
 
     const amountOwed: number = this.splitCost(cost);
 
-    const transactions: ITransaction[] = await this.database.insert('transactions', {
+    const transactions: ITransaction[] = await this.databaseQuery.insert('transactions', {
       name,
       date: dateStr,
       cost,
     });
 
-    await this.database.insert('transaction_users', {
+    await this.databaseQuery.insert('transaction_users', {
       transaction_id: transactions[0].id,
       lender_id: lenderId,
       borrower_id: borrowerId,

--- a/src/tables/TransactionTable.ts
+++ b/src/tables/TransactionTable.ts
@@ -4,7 +4,7 @@ export interface ITransaction {
   id: number;
   name: string;
   cost: number;
-  date: Date;
+  date: Date | string;
 }
 
 export interface ITransactionUser {

--- a/src/tables/TransactionTable.ts
+++ b/src/tables/TransactionTable.ts
@@ -30,13 +30,24 @@ export default class TransactionTable implements ITransactionTable {
 
     this.validate(name, date, cost);
 
+    const dateStr = `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+
     const amountOwed: number = this.splitCost(cost);
 
-    const transaction = await this.database.createTransaction(name, date, cost);
+    const transactions: ITransaction[] = await this.database.insert('transactions', {
+      name,
+      date: dateStr,
+      cost,
+    });
 
-    await this.database.createTransactionUser(transaction.id, lenderId, borrowerId, amountOwed);
+    await this.database.insert('transaction_users', {
+      transaction_id: transactions[0].id,
+      lender_id: lenderId,
+      borrower_id: borrowerId,
+      amount_owed: amountOwed,
+    });
 
-    return transaction;
+    return transactions[0];
   }
 
   private validate(name: string, date: Date, cost: number) {
@@ -45,19 +56,19 @@ export default class TransactionTable implements ITransactionTable {
     }
 
     if (!(date instanceof Date)) {
-      throw new Error('Expected date to be instance of date')
+      throw new Error('Expected date to be instance of date');
     }
 
     if (isNaN(cost) || typeof cost !== 'number') {
-      throw new Error('Expected cost to be a number')
+      throw new Error('Expected cost to be a number');
     }
 
     if (cost <= 0) {
-      throw new Error('Expected cost to be a positive number')
+      throw new Error('Expected cost to be a positive number');
     }
 
     if (cost % 1) {
-      throw new Error('Cost cannot go past the hundredths')
+      throw new Error('Cost cannot go past the hundredths');
     }
   }
 

--- a/src/tables/UserTable.ts
+++ b/src/tables/UserTable.ts
@@ -44,7 +44,8 @@ export default class UserTable implements IUserTable {
   }
 
   async findByName(firstName: string): Promise<IUser | null> {
-    return await this.database.findUserByName(firstName);
+    const users = await this.database.select('users', { first_name: firstName });
+    return users[0];
   }
 
   private titleCase(firstName: string): string {
@@ -55,6 +56,6 @@ export default class UserTable implements IUserTable {
   }
 
   async getAll(): Promise<IUser[]> {
-    return await this.database.getAllUsers();
+    return await this.database.select('users', {});
   }
 }

--- a/src/tables/UserTable.ts
+++ b/src/tables/UserTable.ts
@@ -24,7 +24,11 @@ export default class UserTable implements IUserTable {
 
     await this.validate(firstName);
 
-    return await this.database.createUser(firstName);
+    const users = await this.database.insert('users', {
+      first_name: firstName,
+    });
+
+    return users[0];
   }
 
   private async validate(firstName: string) {
@@ -44,7 +48,10 @@ export default class UserTable implements IUserTable {
   }
 
   private titleCase(firstName: string): string {
-    return firstName.split(' ').map(n => n.charAt(0).toUpperCase() + n.slice(1).toLowerCase()).join(' ');
+    return firstName
+      .split(' ')
+      .map((n) => n.charAt(0).toUpperCase() + n.slice(1).toLowerCase())
+      .join(' ');
   }
 
   async getAll(): Promise<IUser[]> {

--- a/src/tables/UserTable.ts
+++ b/src/tables/UserTable.ts
@@ -1,4 +1,4 @@
-import { IDatabase } from '../Postgres';
+import { IDatabase } from '../PostgresQuery';
 
 export interface IUser {
   id: number;
@@ -6,16 +6,15 @@ export interface IUser {
 }
 
 export interface IUserTable {
-  database: IDatabase;
   create(firstName: string): Promise<IUser>;
   findByName(firstName: string): Promise<IUser | null>;
   getAll(): Promise<IUser[]>;
 }
 
 export default class UserTable implements IUserTable {
-  database: IDatabase;
-  constructor(database: IDatabase) {
-    this.database = database;
+  private databaseQuery: IDatabase;
+  constructor(databaseQuery: IDatabase) {
+    this.databaseQuery = databaseQuery;
   }
 
   async create(firstName: string): Promise<IUser> {
@@ -24,7 +23,7 @@ export default class UserTable implements IUserTable {
 
     await this.validate(firstName);
 
-    const users = await this.database.insert('users', {
+    const users = await this.databaseQuery.insert('users', {
       first_name: firstName,
     });
 
@@ -44,7 +43,7 @@ export default class UserTable implements IUserTable {
   }
 
   async findByName(firstName: string): Promise<IUser | null> {
-    const users = await this.database.select('users', { first_name: firstName });
+    const users = await this.databaseQuery.select('users', { first_name: firstName });
     return users[0];
   }
 
@@ -56,6 +55,6 @@ export default class UserTable implements IUserTable {
   }
 
   async getAll(): Promise<IUser[]> {
-    return await this.database.select('users', {});
+    return await this.databaseQuery.select('users', {});
   }
 }

--- a/src/tables/index.ts
+++ b/src/tables/index.ts
@@ -1,10 +1,12 @@
-import UserTable from './UserTable'
-import Postgres from '../Postgres';
+import UserTable from './UserTable';
+import PG_Interface from '../PG_Interface';
 import TransactionTable from './TransactionTable';
+import PostgresQuery from '../PostgresQuery';
 
-const database = new Postgres;
+const database = new PG_Interface();
+const databaseQuery = new PostgresQuery(database);
 
 export const end = database.end;
 
-export const userTable: UserTable = new UserTable(database);
-export const transactionTable: TransactionTable = new TransactionTable(database);
+export const userTable: UserTable = new UserTable(databaseQuery);
+export const transactionTable: TransactionTable = new TransactionTable(databaseQuery);

--- a/test/PG_Interface.spec.ts
+++ b/test/PG_Interface.spec.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import PG_Interface, { IPG_Interface } from '../src/PG_Interface';
+import { userTable } from '../src/tables';
+
+let pgInterface: IPG_Interface;
+
+describe('PG_Interface', () => {
+  before(async () => {
+    pgInterface = new PG_Interface();
+    await userTable.create('fun user');
+  });
+
+  after(async () => {
+    await pgInterface.end();
+  });
+
+  describe('getConfig', () => {
+    after(async () => {
+      await pgInterface.query('DELETE FROM users;');
+    });
+
+    it('should get config for specified environment', () => {
+      const expected = {
+        driver: 'pg',
+        user: 'test_user',
+        password: '',
+        host: 'localhost',
+        database: 'split_it_test',
+        port: 5432,
+      };
+
+      const config = pgInterface.getConfig('test');
+      expect(config).to.eql(expected);
+    });
+  });
+
+  describe('ended', () => {
+    it('should return if pool ended', () => {
+      const ended = pgInterface.ended;
+
+      expect(ended).to.be.false;
+    });
+  });
+
+  describe('end', () => {
+    it('should end pool', async () => {
+      await pgInterface.end();
+
+      expect(pgInterface.ended).to.be.true;
+    });
+  });
+});

--- a/test/Postgres.spec.ts
+++ b/test/Postgres.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import Postgres, { IPostgres } from '../src/Postgres';
+import Postgres, { IPostgres, IWithId } from '../src/Postgres';
 import { userTable, transactionTable } from '../src/tables';
 import { IUser } from '../src/tables/UserTable';
 import { ITransaction, ITransactionUser } from '../src/tables/TransactionTable';
@@ -29,23 +29,6 @@ describe('Postgres', () => {
 
       const config = postgres.getConfig('test');
       expect(config).to.eql(expected);
-    });
-  });
-
-  describe('query', () => {
-    it('should get config for specified environment', () => {
-      let calledWith = null;
-
-      const query = (sql: any): any => {
-        calledWith = sql;
-      };
-
-      const postgresInstance = new Postgres();
-      postgresInstance.query = query;
-
-      postgresInstance.query('SELECT * FROM users;');
-
-      expect(calledWith).to.equal('SELECT * FROM users;');
     });
   });
 
@@ -106,7 +89,7 @@ describe('Postgres', () => {
   });
 
   describe('select', () => {
-    let energizer: IUser, duracell: IUser;
+    let energizer: IUser & IWithId, duracell: IUser & IWithId;
     before(async () => {
       await postgres.query('DELETE FROM transaction_users;');
       await postgres.query('DELETE FROM transactions;');
@@ -114,7 +97,7 @@ describe('Postgres', () => {
 
       energizer = await userTable.create('Energizer');
       duracell = await userTable.create('Duracell');
-      const eneloop: IUser = await userTable.create('Eneloop');
+      const eneloop: IUser & IWithId = await userTable.create('Eneloop');
       await transactionTable.create(energizer.id, duracell.id, 'Electric Bill', new Date(), 900);
       await transactionTable.create(energizer.id, duracell.id, 'Tesla', new Date(), 10000);
       await transactionTable.create(energizer.id, eneloop.id, 'Charge', new Date(), 1200);

--- a/test/pages/AddTransactionPage.spec.ts
+++ b/test/pages/AddTransactionPage.spec.ts
@@ -3,20 +3,20 @@ import AddTransactionPage from '../../src/pages/AddTransactionPage';
 import MenuPage from '../../src/pages/MenuPage';
 import MockCLI from '../mockClasses/mockCLI';
 import Prompter, { IPrompter, IQuestionOptions } from '../../src/Prompter';
-import Postgres from '../../src/Postgres';
+import PG_Interface from '../../src/PG_Interface';
 import { userTable, transactionTable } from '../../src/tables';
 import { IUser } from '../../src/tables/UserTable';
 import { ITransaction } from '../../src/tables/TransactionTable';
 import chalk from 'chalk';
 
 describe('AddTransactionPage', () => {
-  const postgres = new Postgres;
+  const pgInterface = new PG_Interface();
   let activeUser: IUser, otherUser: IUser, addTransactionPage: AddTransactionPage, mockCLI: MockCLI;
 
   before(async () => {
-    await postgres.query('DELETE FROM transaction_users;');
-    await postgres.query('DELETE FROM transactions;');
-    await postgres.query('DELETE FROM users;');
+    await pgInterface.query('DELETE FROM transaction_users;');
+    await pgInterface.query('DELETE FROM transactions;');
+    await pgInterface.query('DELETE FROM users;');
 
     activeUser = await userTable.create('Kentaro');
     otherUser = await userTable.create('Olga');
@@ -24,16 +24,22 @@ describe('AddTransactionPage', () => {
   });
 
   after(async () => {
-    await postgres.query('DELETE FROM transaction_users;');
-    await postgres.query('DELETE FROM transactions;');
-    await postgres.query('DELETE FROM users;');
+    await pgInterface.query('DELETE FROM transaction_users;');
+    await pgInterface.query('DELETE FROM transactions;');
+    await pgInterface.query('DELETE FROM users;');
 
-    await postgres.end();
+    await pgInterface.end();
   });
 
   beforeEach(async () => {
     mockCLI = new MockCLI();
-    mockCLI.promptMockAnswers = [{ action: 'Olga' }, { input: 'Expensive lunch' }, { date: new Date() }, { confirmation: true }, { number: 100 }];
+    mockCLI.promptMockAnswers = [
+      { action: 'Olga' },
+      { input: 'Expensive lunch' },
+      { date: new Date() },
+      { confirmation: true },
+      { number: 100 },
+    ];
     const prompter: IPrompter = new Prompter(mockCLI);
 
     addTransactionPage = new AddTransactionPage(mockCLI, prompter, activeUser);
@@ -50,7 +56,7 @@ describe('AddTransactionPage', () => {
 
     const expectedTitle: string = chalk.bold('Add a Transaction\n');
 
-    const diplayTitleArgs = mockCLI.printArguments.filter(str => str === expectedTitle);
+    const diplayTitleArgs = mockCLI.printArguments.filter((str) => str === expectedTitle);
     expect(diplayTitleArgs).to.have.lengthOf(mockCLI.promptMockAnswers.length + 1);
   });
 
@@ -100,7 +106,13 @@ describe('AddTransactionPage', () => {
 
     try {
       // mock method
-      transactionTable.create = async (lenderId: number, borrowerId: number, name: string, date: Date, cost: number): Promise<ITransaction> => {
+      transactionTable.create = async (
+        lenderId: number,
+        borrowerId: number,
+        name: string,
+        date: Date,
+        cost: number,
+      ): Promise<ITransaction> => {
         expect(lenderId).to.equal(activeUser.id);
         expect(borrowerId).to.equal(otherUser.id);
 
@@ -118,23 +130,33 @@ describe('AddTransactionPage', () => {
   it('should pass in the active user as borrower if they did not paid', async () => {
     const originalCreate = transactionTable.create; // save original method
 
-    mockCLI.promptMockAnswers = [{ action: 'Olga' }, { input: 'Expensive lunch' }, { date: new Date() }, { confirmation: false }, { number: 100 }];
+    mockCLI.promptMockAnswers = [
+      { action: 'Olga' },
+      { input: 'Expensive lunch' },
+      { date: new Date() },
+      { confirmation: false },
+      { number: 100 },
+    ];
     const prompter: IPrompter = new Prompter(mockCLI);
 
     addTransactionPage = new AddTransactionPage(mockCLI, prompter, activeUser);
 
     try {
       // mock method
-      transactionTable.create = async (lenderId: number, borrowerId: number, name: string, date: Date, cost: number): Promise<ITransaction> => {
+      transactionTable.create = async (
+        lenderId: number,
+        borrowerId: number,
+        name: string,
+        date: Date,
+        cost: number,
+      ): Promise<ITransaction> => {
         expect(lenderId).to.equal(otherUser.id);
         expect(borrowerId).to.equal(activeUser.id);
-
 
         return { id: 0, name, cost, date };
       };
 
       await addTransactionPage.display();
-
     } catch (error) {
       throw error;
     } finally {
@@ -145,14 +167,28 @@ describe('AddTransactionPage', () => {
   it('should continue to ask for a name until the input is not blank', async () => {
     const originalCreate = transactionTable.create; // save original method
 
-    mockCLI.promptMockAnswers = [{ action: 'Olga' }, { input: '' }, { input: ' ' }, { input: 'Expensive lunch' }, { date: new Date() }, { confirmation: false }, { number: 100 }];
+    mockCLI.promptMockAnswers = [
+      { action: 'Olga' },
+      { input: '' },
+      { input: ' ' },
+      { input: 'Expensive lunch' },
+      { date: new Date() },
+      { confirmation: false },
+      { number: 100 },
+    ];
     const prompter: IPrompter = new Prompter(mockCLI);
 
     addTransactionPage = new AddTransactionPage(mockCLI, prompter, activeUser);
 
     try {
       // mock method
-      transactionTable.create = async (_lenderId: number, _borrowerId: number, name: string, date: Date, cost: number): Promise<ITransaction> => {
+      transactionTable.create = async (
+        _lenderId: number,
+        _borrowerId: number,
+        name: string,
+        date: Date,
+        cost: number,
+      ): Promise<ITransaction> => {
         expect(name).to.equal('Expensive lunch');
         return { id: 0, name, cost, date };
       };
@@ -160,9 +196,8 @@ describe('AddTransactionPage', () => {
       await addTransactionPage.display();
 
       const expectedError = 'Invalid name, please try again!';
-      const diplayErrorArgs = mockCLI.printArguments.filter(str => str === expectedError);
+      const diplayErrorArgs = mockCLI.printArguments.filter((str) => str === expectedError);
       expect(diplayErrorArgs).to.have.lengthOf(2);
-
     } catch (error) {
       throw error;
     } finally {
@@ -181,7 +216,7 @@ describe('AddTransactionPage', () => {
       { number: -1 },
       { number: 0 },
       { number: 10.102 },
-      { number: 100.15 }
+      { number: 100.15 },
     ];
     const prompter: IPrompter = new Prompter(mockCLI);
 
@@ -189,7 +224,13 @@ describe('AddTransactionPage', () => {
 
     try {
       // mock method
-      transactionTable.create = async (_lenderId: number, _borrowerId: number, name: string, date: Date, cost: number): Promise<ITransaction> => {
+      transactionTable.create = async (
+        _lenderId: number,
+        _borrowerId: number,
+        name: string,
+        date: Date,
+        cost: number,
+      ): Promise<ITransaction> => {
         expect(cost).to.equal(100.15);
         return { id: 0, name, cost, date };
       };
@@ -197,7 +238,7 @@ describe('AddTransactionPage', () => {
       await addTransactionPage.display();
 
       const expectedError = 'Invalid cost, please enter a positive number with at most two decimal places!';
-      const diplayErrorArgs = mockCLI.printArguments.filter(str => str === expectedError);
+      const diplayErrorArgs = mockCLI.printArguments.filter((str) => str === expectedError);
       expect(diplayErrorArgs).to.have.lengthOf(3);
     } catch (error) {
       throw error;

--- a/test/pages/LoginPage.spec.ts
+++ b/test/pages/LoginPage.spec.ts
@@ -6,22 +6,22 @@ import MockCLI from './../mockClasses/mockCLI';
 import Prompter, { IPrompter, IQuestionOptions } from '../../src/Prompter';
 import { userTable } from '../../src/tables';
 import Separator from 'inquirer/lib/objects/separator';
-import Postgres from '../../src/Postgres';
+import PG_Interface from '../../src/PG_Interface';
 
 describe('LoginPage', () => {
-  const postgres = new Postgres;
+  const pgInterface = new PG_Interface();
 
   before(async () => {
-    await postgres.query('DELETE FROM transaction_users;');
-    await postgres.query('DELETE FROM transactions;');
-    await postgres.query('DELETE FROM users;');
+    await pgInterface.query('DELETE FROM transaction_users;');
+    await pgInterface.query('DELETE FROM transactions;');
+    await pgInterface.query('DELETE FROM users;');
   });
 
   after(async () => {
-    await postgres.query('DELETE FROM transaction_users;');
-    await postgres.query('DELETE FROM transactions;');
-    await postgres.query('DELETE FROM users;');
-    await postgres.end();
+    await pgInterface.query('DELETE FROM transaction_users;');
+    await pgInterface.query('DELETE FROM transactions;');
+    await pgInterface.query('DELETE FROM users;');
+    await pgInterface.end();
   });
 
   it('should ask user if they would like to create a new account', async () => {

--- a/test/tables/TransactionTable.spec.ts
+++ b/test/tables/TransactionTable.spec.ts
@@ -1,12 +1,14 @@
 import { expect } from 'chai';
 import { userTable, transactionTable } from '../../src/tables';
-import Postgres from '../../src/Postgres';
+import PG_Interface from '../../src/PG_Interface';
 import { QueryResult } from 'pg';
 import { ITransactionUser } from '../../src/tables/TransactionTable';
 import { IUser } from '../../src/tables/UserTable';
+import PostgresQuery from '../../src/PostgresQuery';
 
 describe('UserTable model', () => {
-  const postgres = new Postgres();
+  const pgInterface = new PG_Interface();
+  const postgresQuery = new PostgresQuery(pgInterface);
   let user1: IUser, user2: IUser;
 
   const name = 'Electric Bill';
@@ -14,19 +16,19 @@ describe('UserTable model', () => {
   const cost = 1020;
 
   before(async () => {
-    await postgres.query('DELETE FROM transaction_users;');
-    await postgres.query('DELETE FROM transactions;');
-    await postgres.query('DELETE FROM users;');
+    await pgInterface.query('DELETE FROM transaction_users;');
+    await pgInterface.query('DELETE FROM transactions;');
+    await pgInterface.query('DELETE FROM users;');
 
     user1 = await userTable.create('Transaction Table 1');
     user2 = await userTable.create('Transaction Table 2');
   });
 
   after(async () => {
-    await postgres.query('DELETE FROM transaction_users;');
-    await postgres.query('DELETE FROM transactions;');
-    await postgres.query('DELETE FROM users;');
-    await postgres.end();
+    await pgInterface.query('DELETE FROM transaction_users;');
+    await pgInterface.query('DELETE FROM transactions;');
+    await pgInterface.query('DELETE FROM users;');
+    await pgInterface.end();
   });
 
   describe('create', () => {
@@ -35,7 +37,7 @@ describe('UserTable model', () => {
 
       expect(transaction).to.have.all.keys(['id', 'name', 'date', 'cost']);
 
-      const queryResult: QueryResult = await postgres.query('SELECT * FROM transaction_users;');
+      const queryResult: QueryResult = await pgInterface.query('SELECT * FROM transaction_users;');
       const transactionUser: ITransactionUser = queryResult.rows[0];
 
       if (transactionUser) {
@@ -124,7 +126,7 @@ describe('UserTable model', () => {
     it('should randomly round up or down if an odd number is passed in', async () => {
       const transaction = await transactionTable.create(user1.id, user2.id, name, date, 3.33);
 
-      const transactionUsers = await postgres.select('transaction_users', {
+      const transactionUsers = await postgresQuery.select('transaction_users', {
         transaction_id: transaction.id,
         lender_id: user1.id,
         borrower_id: user2.id,

--- a/test/tables/TransactionTable.spec.ts
+++ b/test/tables/TransactionTable.spec.ts
@@ -2,11 +2,11 @@ import { expect } from 'chai';
 import { userTable, transactionTable } from '../../src/tables';
 import Postgres from '../../src/Postgres';
 import { QueryResult } from 'pg';
-import { ITransactionUser } from '../../src/tables/TransactionTable';
+import { ITransactionUser, ITransaction } from '../../src/tables/TransactionTable';
 import { IUser } from '../../src/tables/UserTable';
 
 describe('UserTable model', () => {
-  const postgres = new Postgres;
+  const postgres = new Postgres();
   let user1: IUser, user2: IUser;
 
   const name = 'Electric Bill';
@@ -122,29 +122,43 @@ describe('UserTable model', () => {
     });
 
     it('should randomly round up or down if an odd number is passed in', async () => {
-      const originalMethod = transactionTable.database.createTransactionUser;
+      const originalMethod = transactionTable.database.insert;
+      const passedInArgs: [[string, ITransaction]?, [string, ITransactionUser]?] = [];
 
       try {
-        const mockMethod = async (transactionId: number, lenderId: number, borrowerId: number, amountOwed: number): Promise<ITransactionUser> => {
-          const isValid = amountOwed === 166 || amountOwed === 167; // in cents
+        const mockMethod = async (
+          ...args: [string, ITransaction | ITransactionUser]
+        ): Promise<(ITransaction | ITransactionUser)[]> => {
+          const attributes: ITransaction | ITransactionUser = args[1];
 
-          expect(isValid).to.be.true;
+          passedInArgs.push(args as [string, ITransaction] | [string, ITransactionUser]);
 
-          return {
-            transaction_id: transactionId,
-            lender_id: lenderId,
-            borrower_id: borrowerId,
-            amount_owed: amountOwed,
-          };
-        }
+          return [attributes];
+        };
 
-        transactionTable.database.createTransactionUser = mockMethod;
+        transactionTable.database.insert = mockMethod;
 
         await transactionTable.create(user1.id, user2.id, name, date, 3.33);
+
+        const tableName: string | undefined =
+          passedInArgs && passedInArgs[1] && passedInArgs[1][0] && passedInArgs[1][0];
+        const attributes: ITransactionUser | undefined =
+          passedInArgs && passedInArgs[1] && passedInArgs[1][1] && passedInArgs[1][1];
+
+        if (!attributes) {
+          expect.fail("attributes don't exist");
+        }
+
+        const { amount_owed } = attributes;
+
+        const isValid = amount_owed === 166 || amount_owed === 167; // in cents
+
+        expect(isValid).to.be.true;
+        expect(tableName).to.equal('transaction_users');
       } catch (error) {
         throw error;
       } finally {
-        transactionTable.database.createTransactionUser = originalMethod;
+        transactionTable.database.insert = originalMethod;
       }
     });
   });

--- a/test/tables/UserTable.spec.ts
+++ b/test/tables/UserTable.spec.ts
@@ -3,7 +3,7 @@ import { userTable } from '../../src/tables';
 import Postgres from '../../src/Postgres';
 
 describe('UserTable model', () => {
-  const postgres = new Postgres;
+  const postgres = new Postgres();
 
   before(async () => {
     await postgres.query('DELETE FROM transaction_users;');
@@ -23,7 +23,7 @@ describe('UserTable model', () => {
     it('should create a user and save name as Title Case', async () => {
       await userTable.create('User table model 1');
 
-      const user = await userTable.database.findUserByName('User Table Model 1');
+      const user = await userTable.findByName('User Table Model 1');
 
       if (user) {
         expect(user.first_name).to.equal('User Table Model 1');

--- a/test/tables/UserTable.spec.ts
+++ b/test/tables/UserTable.spec.ts
@@ -1,22 +1,22 @@
 import { expect } from 'chai';
 import { userTable } from '../../src/tables';
-import Postgres from '../../src/Postgres';
+import PG_Interface from '../../src/PG_Interface';
 
 describe('UserTable model', () => {
-  const postgres = new Postgres();
+  const pgInterface = new PG_Interface();
 
   before(async () => {
-    await postgres.query('DELETE FROM transaction_users;');
-    await postgres.query('DELETE FROM transactions;');
-    await postgres.query('DELETE FROM users;');
+    await pgInterface.query('DELETE FROM transaction_users;');
+    await pgInterface.query('DELETE FROM transactions;');
+    await pgInterface.query('DELETE FROM users;');
   });
 
   after(async () => {
-    await postgres.query('DELETE FROM transaction_users;');
-    await postgres.query('DELETE FROM transactions;');
-    await postgres.query('DELETE FROM users;');
+    await pgInterface.query('DELETE FROM transaction_users;');
+    await pgInterface.query('DELETE FROM transactions;');
+    await pgInterface.query('DELETE FROM users;');
 
-    await postgres.end();
+    await pgInterface.end();
   });
 
   describe('create', () => {


### PR DESCRIPTION
`Postgres` was broken up into two classes
- `PG_Interface` acts as the interface to `pg` library. 
  - With the exception of tests, this class should not be accessed.
- `PostgresQuery` has the new `select` and `insert` methods
  - This class will depend on `PG_Interface`, and other classes should depend on `PostgresQuery`
